### PR TITLE
Don't require mongo to import data_layers.

### DIFF
--- a/flask_rest_jsonapi/data_layers/__init__.py
+++ b/flask_rest_jsonapi/data_layers/__init__.py
@@ -1,9 +1,14 @@
 # -*- coding: utf-8 -*-
 
 from flask_rest_jsonapi.data_layers.alchemy import SqlalchemyDataLayer
-from flask_rest_jsonapi.data_layers.mongo import MongoDataLayer
 
 __all__ = [
     'SqlalchemyDataLayer',
-    'MongoDataLayer'
 ]
+
+try:
+    from flask_rest_jsonapi.data_layers.mongo import MongoDataLayer
+except ImportError:
+    pass
+else:
+    __all__.append('MongoDataLayer')


### PR DESCRIPTION
I've tested it:
```
$ pip install -r requirements.txt 
$ ipython3
In [1]: from flask_rest_jsonapi import data_layers

In [2]: dir(data_layers)
Out[2]: 
['SqlalchemyDataLayer',
 '__all__',
 '__builtins__',
 '__cached__',
 '__doc__',
 '__file__',
 '__loader__',
 '__name__',
 '__package__',
 '__path__',
 '__spec__',
 'alchemy',
 'base']

$ pip install pymongo
$ ipython3
In [1]:  from flask_rest_jsonapi import data_layers
   ...: 

In [2]: dir(data_layers)
   ...: 
Out[2]: 
['MongoDataLayer',
 'SqlalchemyDataLayer',
 '__all__',
 '__builtins__',
 '__cached__',
 '__doc__',
 '__file__',
 '__loader__',
 '__name__',
 '__package__',
 '__path__',
 '__spec__',
 'alchemy',
 'base',
 'mongo']
```