### PR TITLE
Checking if Content-Type is present in the request headers

### DIFF
--- a/flask_rest_jsonapi/decorators.py
+++ b/flask_rest_jsonapi/decorators.py
@@ -17,7 +17,7 @@ def check_headers(func):
     @wraps(func)
     def wrapped(*args, **kwargs):
         if request.method in ('POST', 'PATCH'):
-            if request.headers['Content-Type'] != 'application/vnd.api+json':
+            if 'Content-Type' not in request.headers or request.headers['Content-Type'] != 'application/vnd.api+json':
                 error = json.dumps(jsonapi_errors([{'source': '',
                                                     'detail': "Content-Type header must be application/vnd.api+json",
                                                     'title': 'InvalidRequestHeader',


### PR DESCRIPTION
In decorators.py, there is no check if the Content-Type is present in the headers, which will raise an uncaught exception if we try to use the API in the browser. This check will make sure that the header is present otherwise it will return the json response with 415