### PR TITLE
convert delete method's response meta to an object

### DIFF
--- a/flask_rest_jsonapi/resource.py
+++ b/flask_rest_jsonapi/resource.py
@@ -270,7 +270,7 @@ class ResourceDetail(with_metaclass(ResourceMeta, Resource)):
         obj = self._data_layer.get_object(kwargs)
         self._data_layer.delete_object(obj, kwargs)
 
-        result = {'meta': 'Object successful deleted'}
+        result = {'meta': {'message': 'Object successfully deleted'}}
         self.after_delete(result)
         return result
 


### PR DESCRIPTION
Per the JSON API specification: "Where specified, a meta member can be used .. The value of each meta member MUST be an object" (http://jsonapi.org/format/#document-meta)