### PR TITLE
Fix parsing of Accept header.

### DIFF
--- a/flask_rest_jsonapi/decorators.py
+++ b/flask_rest_jsonapi/decorators.py
@@ -23,7 +23,7 @@ def check_headers(func):
                                                     'title': 'InvalidRequestHeader',
                                                     'status': 415}]))
                 return make_response(error, 415, {'Content-Type': 'application/vnd.api+json'})
-        if request.headers.get('Accept') and request.headers['Accept'] != 'application/vnd.api+json':
+        if request.headers.get('Accept') and not 'application/vnd.api+json' in request.accept_mimetypes:
             error = json.dumps(jsonapi_errors([{'source': '',
                                                 'detail': "Accept header must be application/vnd.api+json",
                                                 'title': 'InvalidRequestHeader',


### PR DESCRIPTION
JSONAPI 1.0 specification says:

“Clients that include the JSON API media type in their Accept header MUST specify the media type there at least once without any media type parameters.”

That means, that there may be other acceptable MIME types, which the string comparison that was in place before prevented.

This should also help with issue #13.