### PR TITLE
Force string comparison for id field in patch.

### DIFF
--- a/flask_rest_jsonapi/resource.py
+++ b/flask_rest_jsonapi/resource.py
@@ -248,7 +248,7 @@ class ResourceDetail(with_metaclass(ResourceMeta, Resource)):
 
         if 'id' not in json_data['data']:
             raise BadRequest('/data/id', 'Missing id in "data" node')
-        if json_data['data']['id'] != str(kwargs[self.data_layer.get('url_field', 'id')]):
+        if str(json_data['data']['id']) != str(kwargs[self.data_layer.get('url_field', 'id')]):
             raise BadRequest('/data/id', 'Value of id does not match the resource identifier in url')
 
         self.before_patch(args, kwargs, data=data)


### PR DESCRIPTION
The patch code expected the id in the data object to be a string, while Flask-REST-JSONAPI itself delivers it as integer if it is one in the schema.

This made it a bit awkward to transform a loaded object into a patch object. This commit forces casting both sides of the comparison to string.