### PR TITLE
Fix #60: Allow renaming columns in Model

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,4 @@
+dist: trusty
 language: python
 python:
   - '2.7'

--- a/flask_rest_jsonapi/data_layers/alchemy.py
+++ b/flask_rest_jsonapi/data_layers/alchemy.py
@@ -56,7 +56,7 @@ class SqlalchemyDataLayer(BaseDataLayer):
         """
         self.before_get_object(view_kwargs)
 
-        id_field = getattr(self, 'id_field', inspect(self.model).primary_key[0].name)
+        id_field = getattr(self, 'id_field', inspect(self.model).primary_key[0].key)
         try:
             filter_field = getattr(self.model, id_field)
         except Exception:


### PR DESCRIPTION
This should not impact existing installation, as quoting the sqlalchemy doc: 

> A mapping by default shares the same name for a Column as that of the mapped attribute - specifically it matches the Column.key attribute on Column, which by default is the same as the Column.name.
http://docs.sqlalchemy.org/en/latest/orm/mapping_columns.html

`Column.key == Column.name`