### PR TITLE
call self.init_app if Api was created with a app

### DIFF
--- a/flask_rest_jsonapi/api.py
+++ b/flask_rest_jsonapi/api.py
@@ -26,6 +26,9 @@ class Api(object):
         self.resource_registry = []
         self.decorators = decorators or tuple()
 
+        if app is not None:
+            self.init_app(app, blueprint)
+
     def init_app(self, app=None, blueprint=None):
         """Update flask application with our api
 


### PR DESCRIPTION
call `self.init_app(app)` on `Api.__init__` to avoid external call for init_app when using `Api(app)`
also by side-effect, solves the issue with PAGE_SIZE not set when not using `init_app`

current:
```python
app = Flask(__name__)
api = Api(app)
api.init_app(app)  # required to avoid KeyError on app.config['PAGE_SIZE']
```

now:
```python
app = Flask(__name__)
api = Api(app)
```