### PR TITLE
pull request for fixing pinned marshmallow 2.13.1 in setup.py to 2.*.*

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -28,7 +28,7 @@ setup(
     platforms='any',
     install_requires=['six',
                       'Flask>=0.11',
-                      'marshmallow==2.13.1',
+                      'marshmallow==2.*.*',
                       'marshmallow_jsonapi',
                       'sqlalchemy'],
     setup_requires=['pytest-runner'],


### PR DESCRIPTION
This request is for resolving https://github.com/miLibris/flask-rest-jsonapi/issues/68. 

The marshmallow verison is currently fixed to 2.13.1 which makes it hard if someone (like me) wants to integrate flask-rest-jsonapi into a existing application which uses another verion of marshmallow.

marshmallow_jsonapi requires 'marshmallow>=2.3.0'. does flask-rest-jsonapi depend on any specific features of marshmallow which where introduced after version 2.3.0? Basically between 2.3.0 and 2.13.1, no backward incompatible changes should have been made.