### PR TITLE
Fix REWRITABLE_METHODS list in Base Datalayer

### DIFF
--- a/flask_rest_jsonapi/data_layers/base.py
+++ b/flask_rest_jsonapi/data_layers/base.py
@@ -19,7 +19,7 @@ class BaseDataLayer(object):
                           'after_update_object',
                           'before_delete_object',
                           'after_delete_object',
-                          'before_create_relationship'
+                          'before_create_relationship',
                           'after_create_relationship',
                           'before_get_relationship',
                           'after_get_relationship',


### PR DESCRIPTION
Found a typo in the base datalayer which affects our datalayers inheriting from it. 