### PR TITLE
fix bug Api(decorators=(mydecorators,)), mydecorator not work for my reso…

### DIFF
--- a/flask_rest_jsonapi/api.py
+++ b/flask_rest_jsonapi/api.py
@@ -60,7 +60,6 @@ class Api(object):
         :param dict kwargs: additional options of the route
         """
         resource.view = view
-        view_func = resource.as_view(view)
         url_rule_options = kwargs.get('url_rule_options') or dict()
 
         for decorator in self.decorators:
@@ -68,6 +67,8 @@ class Api(object):
                 resource.decorators += self.decorators
             else:
                 resource.decorators = self.decorators
+
+        view_func = resource.as_view(view)
 
         if self.blueprint is not None:
             resource.view = '.'.join([self.blueprint.name, resource.view])


### PR DESCRIPTION
fix Api(decorators=()) not work
---
when I use the api by `api = Api(decorators=(mydecorator,))`, found mydecorator not work ,so I review the origin code , I found it in Api.route()
```python
view_func = resource.as_view(view)
```
is before

```python
for decorator in self.decorators:
    if hasattr(resource, 'decorators'):
        resource.decorators += self.decorators
    else:
        resource.decorators = self.decorators
```
so mydecorator did not work

because that
I changed the code, set  the order, mydecorator can work in each func


