### PR TITLE
Enable to bypass automatic exception conversion to JsonApiException

### DIFF
--- a/docs/configuration.rst
+++ b/docs/configuration.rst
@@ -3,9 +3,10 @@
 Configuration
 =============
 
-You have access to 3 configration keys:
+You have access to 5 configration keys:
 
 * PAGE_SIZE: the default page size (default is 30)
 * MAX_PAGE_SIZE: the maximum page size. If you speficy a page size greater than this value you will receive 400 Bad Request response.
 * MAX_INCLUDE_DEPTH: the maximum length of an include through schema relationships
 * ALLOW_DISABLE_PAGINATION: if you want to disallow to disable pagination you can set this configuration key to False
+* CATCH_EXCEPTIONS: if you want flask_rest_jsonapi to catch all exceptions and return as JsonApiException (default is True)

--- a/flask_rest_jsonapi/resource.py
+++ b/flask_rest_jsonapi/resource.py
@@ -73,7 +73,7 @@ class Resource(MethodView):
                                  e.status,
                                  headers)
         except Exception as e:
-            if current_app.config['DEBUG'] is True:
+            if current_app.config['DEBUG'] or current_app.config.get('CATCH_EXCEPTIONS', True) is False:
                 raise e
 
             if 'sentry' in current_app.extensions:


### PR DESCRIPTION
Until now all exceptions was catched and converted to JsonApiException.
There was no way how to use custom error catcher like Airbrake.
Setting new configuration parameter `CATCH_EXCEPTIONS` to `False` will correct this behaviour. 
Default `CATCH_EXCEPTIONS` is `True` so no breaking changes is introduced.