### PR TITLE
Complete source tarball.

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,0 +1,2 @@
+include LICENSE
+recursive-include docs examples tests


### PR DESCRIPTION
Not including the license file made the tarball illegal; including docs and tests makes it easier and better to integrate into Debian aswell.