### PR TITLE
Fix links for Flask-restful and Falsk-restless

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -11,7 +11,7 @@
 Flask-REST-JSONAPI
 ##################
 
-Flask-REST-JSONAPI is a flask extension for building REST APIs. It combines the power of `Flask-Restless <https://flask-restless.readthedocs.io/en/stable/>`_ and the flexibility of `Flask-RESTful <http://flask-restful-cn.readthedocs.io/en/0.3.5/a>`_ around a strong specification `JSONAPI 1.0 <http://jsonapi.org/>`_. This framework is designed to quickly build REST APIs and fit the complexity of real life projects with legacy data and multiple data storages.
+Flask-REST-JSONAPI is a flask extension for building REST APIs. It combines the power of `Flask-Restless <https://flask-restless.readthedocs.io/>`_ and the flexibility of `Flask-RESTful <https://flask-restful.readthedocs.io/>`_ around a strong specification `JSONAPI 1.0 <http://jsonapi.org/>`_. This framework is designed to quickly build REST APIs and fit the complexity of real life projects with legacy data and multiple data storages.
 
 Install
 =======


### PR DESCRIPTION
The Flask-restful was broken, ant it better to use the base readthedocs URL, and the the target project redirect to whatever they think appropriate.