### PR TITLE
Auto-deploy to pypi on release tag

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -15,3 +15,21 @@ script:
   - coverage run --source flask_rest_jsonapi -m pytest -v
 after_success:
   - coveralls
+before_deploy: "python setup.py sdist"
+deploy:
+  - provider: releases
+    api_key:
+      secure: your_github_password_encrypted_using_your_travis_project_private_key
+    file_glob: true
+    file: dist/Flask-REST-JSONAPI-*.tar.gz
+    skip_cleanup: true
+    on:
+      tags: true
+      repo: miLibris/flask-rest-jsonapi
+  - provider: pypi
+    user: akira-dev
+    password:
+      secure: your_pypi_password_encrypted_using_your_travis_project_private_key
+    on:
+      tags: true
+      repo: miLibris/flask-rest-jsonapi


### PR DESCRIPTION
Added the necessary template to `.travis.yml` file to auto-deploy on pypi and create/push the release to GitHub releases.

@akira-dev Don't forget to adapt the `secure` fields to include your encrypted password or tokens. You may use `travis` cli for such task. I personnaly use it in a docker container `docker run -it --rm -v $PWD:/repo -v ~/.travis:/travis ubergarm/travis-ci-cli envrypt` from inside your git clone.

The doc regarding such conf: https://docs.travis-ci.com/user/deployment/releases#authenticating-with-an-oauth-token