### PR TITLE
PATCH should compare the id using the url_field defined in the data_layer class

### DIFF
--- a/flask_rest_jsonapi/resource.py
+++ b/flask_rest_jsonapi/resource.py
@@ -271,7 +271,7 @@ class ResourceDetail(with_metaclass(ResourceMeta, Resource)):
         if 'id' not in json_data['data']:
             raise BadRequest('Missing id in "data" node',
                              source={'pointer': '/data/id'})
-        if json_data['data']['id'] != str(kwargs[self.data_layer.get('url_field', 'id')]):
+        if (str(json_data['data']['id']) != str(kwargs[getattr(self._data_layer, 'url_field', 'id')])):
             raise BadRequest('Value of id does not match the resource identifier in url',
                              source={'pointer': '/data/id'})
 


### PR DESCRIPTION
We've discovered that when trying to implement the PATCH method against a data layer that redefines the `url_field` in a subclass of SqlalchemyDataLayer rather than by passing it in the `data_layer` dict in the subclass of ResourceDetail, the PATCH fails with `KeyError: 'id'` as the alternative field name is ignored. This patch fixes this by always looking in `self._data_layer` for `url_field` which is consistent with where you look for it in other places.

I also had to stringify the id on both sides of the comparison otherwise it failed for integer IDs.