### PR TITLE
Parse relationship from url with trailing slashes

### DIFF
--- a/flask_rest_jsonapi/resource.py
+++ b/flask_rest_jsonapi/resource.py
@@ -503,7 +503,8 @@ class ResourceRelationship(with_metaclass(ResourceMeta, Resource)):
 
     def _get_relationship_data(self):
         """Get useful data for relationship management"""
-        relationship_field = request.path.split('/')[-1].replace('-', '_')
+        url = request.path.rstrip('/')
+        relationship_field = url.split('/')[-1].replace('-', '_')
 
         if relationship_field not in get_relationships(self.schema):
             raise RelationNotFound("{} has no attribute {}".format(self.schema.__name__, relationship_field))


### PR DESCRIPTION
After issuing a request to an endpoint like `/<resource_a>/<id>/relationships/<resource_b>/` , the resource_b field is not identified as a relationship.
I'm pretty sure the following line is causing the issue: https://github.com/miLibris/flask-rest-jsonapi/blob/ad3f90f81955fa41aaf0fb8c49a75a5fbe334f5f/flask_rest_jsonapi/resource.py#L506

This is because the last item of request.path.split('/') is actually an empty string:
```
>>> s = '/api/users/5/relationships/organization/'
>>> s.split('/')
['', 'api', 'users', '5', 'relationships', 'organization', '']
>>> s = '/api/users/5/relationships/organization'
>>> s.split('/')
['', 'api', 'users', '5', 'relationships', 'organization']
```