### PR TITLE
Added optional callback SqlalchemyDataLayer.unhandled_exception_forma…

### DIFF
--- a/docs/data_layer.rst
+++ b/docs/data_layer.rst
@@ -99,6 +99,20 @@ Optional parameters:
 
     :id_field: the field used as identifier field instead of the primary key of the model
     :url_field: the name of the parameter in the route to get value to filter with. Instead "id" is used.
+    :unhandled_exception_formatter: callback function used to format unexpected exceptions in data layer. It accepts caught exception and returns dict of kwargs for JsonApiException initializer.
+
+Example:
+
+.. code-block:: python
+
+    def sa_exception_formatter(exc):
+        return {"detail": "SQLAlchemy complains!", "status": 405}
+
+    class ComputerList(ResourceList):
+        schema = ComputerSchema
+        data_layer = {'session': db.session,
+                      'model': Computer,
+                      'unhandled_exception_formatter': sa_exception_formatter}
 
 By default SQLAlchemy eagerload related data specified in include querystring parameter. If you want to disable this feature you must add eagerload_includes: False to data layer parameters.
 

--- a/flask_rest_jsonapi/data_layers/alchemy.py
+++ b/flask_rest_jsonapi/data_layers/alchemy.py
@@ -35,6 +35,15 @@ class SqlalchemyDataLayer(BaseDataLayer):
             raise Exception("You must provide a model in data_layer_kwargs to use sqlalchemy data layer in {}"
                             .format(self.resource.__name__))
 
+    def _client_formatted(self, exc):
+        try:
+            data = self.unhandled_exception_formatter(exc)
+
+        except AttributeError:
+            data = None
+
+        return data
+
     def create_object(self, data, view_kwargs):
         """Create an object through sqlalchemy
 
@@ -62,7 +71,11 @@ class SqlalchemyDataLayer(BaseDataLayer):
             raise e
         except Exception as e:
             self.session.rollback()
-            raise JsonApiException("Object creation error: " + str(e), source={'pointer': '/data'})
+            e_data = self._client_formatted(e)
+            raise JsonApiException(**(
+                e_data if e_data
+                else {"source": {'pointer': '/data'}, "detail": "Object creation error: " + str(e)}
+            ))
 
         self.after_create_object(obj, data, view_kwargs)
 
@@ -164,7 +177,11 @@ class SqlalchemyDataLayer(BaseDataLayer):
             raise e
         except Exception as e:
             self.session.rollback()
-            raise JsonApiException("Update object error: " + str(e), source={'pointer': '/data'})
+            e_data = self._client_formatted(e)
+            raise JsonApiException(**(
+                e_data if e_data
+                else {"source": {'pointer': '/data'}, "detail": "Update object error: " + str(e)}
+            ))
 
         self.after_update_object(obj, data, view_kwargs)
 
@@ -190,7 +207,10 @@ class SqlalchemyDataLayer(BaseDataLayer):
             raise e
         except Exception as e:
             self.session.rollback()
-            raise JsonApiException("Delete object error: " + str(e))
+            e_data = self._client_formatted(e)
+            raise JsonApiException(**(
+                e_data if e_data else {"detail": "Delete object error: " + str(e)}
+            ))
 
         self.after_delete_object(obj, view_kwargs)
 
@@ -247,7 +267,10 @@ class SqlalchemyDataLayer(BaseDataLayer):
             raise e
         except Exception as e:
             self.session.rollback()
-            raise JsonApiException("Create relationship error: " + str(e))
+            e_data = self._client_formatted(e)
+            raise JsonApiException(**(
+                e_data if e_data else {"detail": "Create relationship error: " + str(e)}
+            ))
 
         self.after_create_relationship(obj, updated, json_data, relationship_field, related_id_field, view_kwargs)
 
@@ -346,7 +369,10 @@ class SqlalchemyDataLayer(BaseDataLayer):
             raise e
         except Exception as e:
             self.session.rollback()
-            raise JsonApiException("Update relationship error: " + str(e))
+            e_data = self._client_formatted(e)
+            raise JsonApiException(**(
+                e_data if e_data else {"detail": "Update relationship error: " + str(e)}
+            ))
 
         self.after_update_relationship(obj, updated, json_data, relationship_field, related_id_field, view_kwargs)
 
@@ -396,7 +422,10 @@ class SqlalchemyDataLayer(BaseDataLayer):
             raise e
         except Exception as e:
             self.session.rollback()
-            raise JsonApiException("Delete relationship error: " + str(e))
+            e_data = self._client_formatted(e)
+            raise JsonApiException(**(
+                e_data if e_data else {"detail": "Delete relationship error: " + str(e)}
+            ))
 
         self.after_delete_relationship(obj, updated, json_data, relationship_field, related_id_field, view_kwargs)
 


### PR DESCRIPTION
Related to #72

I'd introduced another optional argument for SQLAlchemy data layer that works like this:

```python
def sa_exception_formatter(exc):
    return {"detail": "SQLAlchemy complains!", "status": 405}

class ComputerList(ResourceList):
    schema = ComputerSchema
    data_layer = {'session': db.session,
                  'model': Computer,
                  'unhandled_exception_formatter': sa_exception_formatter}
```

I was playing with idea to generalize this more, but after inspecting existing code, I don't think it is needed - in 99% cases `flask-rest-jsonapi` already does the **only** sane thing. 

So, this new callback gets (optionally) called only in places where unexpected exception had happened.

What do you think?