### PR TITLE
Allow eagerload_includes: False option on ResourceDetail

### DIFF
--- a/flask_rest_jsonapi/data_layers/alchemy.py
+++ b/flask_rest_jsonapi/data_layers/alchemy.py
@@ -87,7 +87,7 @@ class SqlalchemyDataLayer(BaseDataLayer):
 
         query = self.retrieve_object_query(view_kwargs, filter_field, filter_value)
 
-        if qs is not None:
+        if qs is not None and getattr(self, 'eagerload_includes', True):
             query = self.eagerload_includes(query, qs)
 
         try:


### PR DESCRIPTION
Currently the 'eagerload_includes' parameter for a SQLAlchemy data layer can only be set to `False` for a ResourceList. For a ResourceDetail, this results in a 'bool not callable' error. This PR attempts to fix that