### PR TITLE
Propagate flask_rest_jsonapi errors to flask

### DIFF
--- a/flask_rest_jsonapi/decorators.py
+++ b/flask_rest_jsonapi/decorators.py
@@ -79,7 +79,7 @@ def jsonapi_exception_formatter(func):
                                  e.status,
                                  headers)
         except Exception as e:
-            if current_app.config['DEBUG'] is True or current_app.config['PROPAGATE_EXCEPTIONS'] is True:
+            if current_app.config['DEBUG'] is True or current_app.config.get('PROPAGATE_EXCEPTIONS') is True:
                 raise e
 
             if 'sentry' in current_app.extensions:

--- a/flask_rest_jsonapi/decorators.py
+++ b/flask_rest_jsonapi/decorators.py
@@ -79,7 +79,7 @@ def jsonapi_exception_formatter(func):
                                  e.status,
                                  headers)
         except Exception as e:
-            if current_app.config['DEBUG'] is True:
+            if current_app.config['DEBUG'] is True or current_app.config['PROPAGATE_EXCEPTIONS'] is True:
                 raise e
 
             if 'sentry' in current_app.extensions:


### PR DESCRIPTION
When the `ROPAGATE_EXCEPTIONS` is set, it is desirable to re-throw the error such that any registered flask error handlers will take care of it.
This fixes the error described in issue #162.