### PR TITLE
Added support for Decimal type in JSON encoder

### DIFF
--- a/flask_rest_jsonapi/utils.py
+++ b/flask_rest_jsonapi/utils.py
@@ -3,6 +3,7 @@
 import json
 from uuid import UUID
 from datetime import datetime
+from decimal import Decimal
 
 
 class JSONEncoder(json.JSONEncoder):
@@ -11,4 +12,6 @@ class JSONEncoder(json.JSONEncoder):
             return obj.isoformat()
         elif isinstance(obj, UUID):
             return str(obj)
+        elif isinstance(obj, Decimal):
+            return str(obj)            
         return json.JSONEncoder.default(self, obj)


### PR DESCRIPTION
Added handling of Decimal type to JSON Encoder (since the switch to 'json.dumps' Decimal type was no longer supported).