### PR TITLE
Python 3 and Marshmallow 3

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,13 +5,8 @@ python:
   - '3.5'
   - '3.6'
   - 'pypy3'
-install:
-  - pip install -r requirements.txt
-  - pip install coveralls coverage
-  - pip install -U setuptools
-  - pip install pytest --upgrade
 script:
-  - python setup.py install
+  - pip install .
   - coverage run --source flask_rest_jsonapi -m pytest -v
 after_success:
   - coveralls

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,9 @@
 dist: trusty
 language: python
 python:
-  - '3.4'
   - '3.5'
   - '3.6'
+  - '3.7'
   - 'pypy3'
 script:
   - pip install .[dev]

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,7 +6,7 @@ python:
   - '3.6'
   - 'pypy3'
 script:
-  - pip install .
+  - pip install .[dev]
   - coverage run --source flask_rest_jsonapi -m pytest -v
 after_success:
   - coveralls

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,10 +1,10 @@
 dist: trusty
 language: python
 python:
-  - '2.7'
   - '3.4'
   - '3.5'
-  - 'pypy'
+  - '3.6'
+  - 'pypy3'
 install:
   - pip install -r requirements.txt
   - pip install coveralls coverage

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,4 @@
-dist: trusty
+dist: xenial
 language: python
 python:
   - '3.5'

--- a/flask_rest_jsonapi/resource.py
+++ b/flask_rest_jsonapi/resource.py
@@ -128,7 +128,7 @@ class ResourceList(with_metaclass(ResourceMeta, Resource)):
                                 qs,
                                 qs.include)
 
-        result = schema.dump(objects).data
+        result = schema.dump(objects)
 
         view_kwargs = request.view_args if getattr(self, 'view_kwargs', None) is True else dict()
         add_pagination_links(result,
@@ -155,7 +155,7 @@ class ResourceList(with_metaclass(ResourceMeta, Resource)):
                                 qs.include)
 
         try:
-            data, errors = schema.load(json_data)
+            data = schema.load(json_data)
         except IncorrectTypeError as e:
             errors = e.messages
             for error in errors['errors']:
@@ -169,17 +169,11 @@ class ResourceList(with_metaclass(ResourceMeta, Resource)):
                 message['title'] = "Validation error"
             return errors, 422
 
-        if errors:
-            for error in errors['errors']:
-                error['status'] = "422"
-                error['title'] = "Validation error"
-            return errors, 422
-
         self.before_post(args, kwargs, data=data)
 
         obj = self.create_object(data, kwargs)
 
-        result = schema.dump(obj).data
+        result = schema.dump(obj)
 
         if result['data'].get('links', {}).get('self'):
             final_result = (result, 201, {'Location': result['data']['links']['self']})
@@ -235,7 +229,7 @@ class ResourceDetail(with_metaclass(ResourceMeta, Resource)):
                                 qs,
                                 qs.include)
 
-        result = schema.dump(obj).data
+        result = schema.dump(obj)
 
         final_result = self.after_get(result)
 
@@ -258,7 +252,7 @@ class ResourceDetail(with_metaclass(ResourceMeta, Resource)):
                                 qs.include)
 
         try:
-            data, errors = schema.load(json_data)
+            data = schema.load(json_data)
         except IncorrectTypeError as e:
             errors = e.messages
             for error in errors['errors']:
@@ -272,12 +266,6 @@ class ResourceDetail(with_metaclass(ResourceMeta, Resource)):
                 message['title'] = "Validation error"
             return errors, 422
 
-        if errors:
-            for error in errors['errors']:
-                error['status'] = "422"
-                error['title'] = "Validation error"
-            return errors, 422
-
         if 'id' not in json_data['data']:
             raise BadRequest('Missing id in "data" node',
                              source={'pointer': '/data/id'})
@@ -289,7 +277,7 @@ class ResourceDetail(with_metaclass(ResourceMeta, Resource)):
 
         obj = self.update_object(data, qs, kwargs)
 
-        result = schema.dump(obj).data
+        result = schema.dump(obj)
 
         final_result = self.after_patch(result)
 
@@ -373,7 +361,7 @@ class ResourceRelationship(with_metaclass(ResourceMeta, Resource)):
             schema = compute_schema(self.schema, dict(), qs, qs.include)
 
             serialized_obj = schema.dump(obj)
-            result['included'] = serialized_obj.data.get('included', dict())
+            result['included'] = serialized_obj.get('included', dict())
 
         final_result = self.after_get(result)
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,0 @@
-six
-Flask>=0.11
-marshmallow==2.18.0
-marshmallow_jsonapi
-sqlalchemy

--- a/setup.py
+++ b/setup.py
@@ -28,7 +28,7 @@ setup(
         'six',
         'Flask>=0.11',
         'marshmallow>=3.1.0',
-        'marshmallow_jsonapi>=0.11.0',
+        'marshmallow_jsonapi>=0.21.0',
         'sqlalchemy'
     ],
     setup_requires=['pytest-runner'],

--- a/setup.py
+++ b/setup.py
@@ -32,5 +32,12 @@ setup(
     ],
     setup_requires=['pytest-runner'],
     tests_require=['pytest'],
-    extras_require={'tests': 'pytest', 'docs': 'sphinx'}
+    extras_require={
+        'tests': [
+        'pytest',
+        'coveralls',
+        'coverage'
+        ],
+        'docs': 'sphinx'
+    }
 )

--- a/setup.py
+++ b/setup.py
@@ -27,7 +27,7 @@ setup(
         'six',
         'Flask>=0.11',
         'marshmallow>=3.1.0',
-        'marshmallow_jsonapi>=0.21.0',
+        'marshmallow_jsonapi>=0.22.0',
         'sqlalchemy'
     ],
     setup_requires=['pytest-runner'],

--- a/setup.py
+++ b/setup.py
@@ -33,10 +33,10 @@ setup(
     setup_requires=['pytest-runner'],
     tests_require=['pytest'],
     extras_require={
-        'tests': [
-        'pytest',
-        'coveralls',
-        'coverage'
+        'dev': [
+            'pytest',
+            'coveralls',
+            'coverage'
         ],
         'docs': 'sphinx'
     }

--- a/setup.py
+++ b/setup.py
@@ -1,8 +1,6 @@
 from setuptools import setup, find_packages
 
-
 __version__ = '0.30.1'
-
 
 setup(
     name="Flask-REST-JSONAPI",
@@ -26,11 +24,13 @@ setup(
     packages=find_packages(exclude=['tests']),
     zip_safe=False,
     platforms='any',
-    install_requires=['six',
-                      'Flask>=0.11',
-                      'marshmallow==2.18.0',
-                      'marshmallow_jsonapi',
-                      'sqlalchemy'],
+    install_requires=[
+        'six',
+        'Flask>=0.11',
+        'marshmallow>=3.1.0',
+        'marshmallow_jsonapi>=0.11.0',
+        'sqlalchemy'
+    ],
     setup_requires=['pytest-runner'],
     tests_require=['pytest'],
     extras_require={'tests': 'pytest', 'docs': 'sphinx'}

--- a/setup.py
+++ b/setup.py
@@ -27,7 +27,7 @@ setup(
         'six',
         'Flask>=0.11',
         'marshmallow>=3.1.0',
-        'marshmallow_jsonapi>=0.22.0',
+        'marshmallow_jsonapi>=0.11.0',
         'sqlalchemy'
     ],
     setup_requires=['pytest-runner'],

--- a/setup.py
+++ b/setup.py
@@ -13,11 +13,10 @@ setup(
     license='MIT',
     classifiers=[
         'Framework :: Flask',
-        'Programming Language :: Python :: 2',
-        'Programming Language :: Python :: 2.7',
         'Programming Language :: Python :: 3',
         'Programming Language :: Python :: 3.4',
         'Programming Language :: Python :: 3.5',
+        'Programming Language :: Python :: 3.6',
         'License :: OSI Approved :: MIT License',
     ],
     keywords='web api rest jsonapi flask sqlalchemy marshmallow',

--- a/tests/test_sqlalchemy_data_layer.py
+++ b/tests/test_sqlalchemy_data_layer.py
@@ -664,7 +664,7 @@ def test_get_list(client, register_routes, person, person_2):
                 ])
         })
         response = client.get('/persons' + '?' + querystring, content_type='application/vnd.api+json')
-        assert response.status_code == 200
+        assert response.status_code == 200, response.json['errors']
 
 
 def test_get_list_with_simple_filter(client, register_routes, person, person_2):
@@ -676,20 +676,20 @@ def test_get_list_with_simple_filter(client, register_routes, person, person_2):
                                  'filter[name]': 'test'
                                  })
         response = client.get('/persons' + '?' + querystring, content_type='application/vnd.api+json')
-        assert response.status_code == 200
+        assert response.status_code == 200, response.json['errors']
 
 
 def test_get_list_disable_pagination(client, register_routes):
     with client:
         querystring = urlencode({'page[size]': 0})
         response = client.get('/persons' + '?' + querystring, content_type='application/vnd.api+json')
-        assert response.status_code == 200
+        assert response.status_code == 200, response.json['errors']
 
 
 def test_head_list(client, register_routes):
     with client:
         response = client.head('/persons', content_type='application/vnd.api+json')
-        assert response.status_code == 200
+        assert response.status_code == 200, response.json['errors']
 
 
 def test_post_list(client, register_routes, computer):
@@ -714,7 +714,7 @@ def test_post_list(client, register_routes, computer):
 
     with client:
         response = client.post('/persons', data=json.dumps(payload), content_type='application/vnd.api+json')
-        assert response.status_code == 201
+        assert response.status_code == 201, response.json['errors']
 
 
 def test_post_list_nested_no_join(client, register_routes, computer):
@@ -736,7 +736,7 @@ def test_post_list_nested_no_join(client, register_routes, computer):
         response = client.post('/string_json_attribute_persons', data=json.dumps(payload),
                                content_type='application/vnd.api+json')
         print(response.get_data())
-        assert response.status_code == 201
+        assert response.status_code == 201, response.json['errors']
         assert json.loads(response.get_data())['data']['attributes']['address']['street'] == 'test_street'
 
 
@@ -766,7 +766,7 @@ def test_post_list_nested(client, register_routes, computer):
 
     with client:
         response = client.post('/persons', data=json.dumps(payload), content_type='application/vnd.api+json')
-        assert response.status_code == 201
+        assert response.status_code == 201, response.json['errors']
         assert json.loads(response.get_data())['data']['attributes']['tags'][0]['key'] == 'k1'
 
 
@@ -790,13 +790,13 @@ def test_post_list_single(client, register_routes, person):
 
     with client:
         response = client.post('/computers', data=json.dumps(payload), content_type='application/vnd.api+json')
-        assert response.status_code == 201
+        assert response.status_code == 201, response.json['errors']
 
 
 def test_get_detail(client, register_routes, person):
     with client:
         response = client.get('/persons/' + str(person.person_id), content_type='application/vnd.api+json')
-        assert response.status_code == 200
+        assert response.status_code == 200, response.json['errors']
 
 
 def test_patch_detail(client, register_routes, computer, person):
@@ -824,7 +824,7 @@ def test_patch_detail(client, register_routes, computer, person):
         response = client.patch('/persons/' + str(person.person_id),
                                 data=json.dumps(payload),
                                 content_type='application/vnd.api+json')
-        assert response.status_code == 200
+        assert response.status_code == 200, response.json['errors']
 
 
 def test_patch_detail_nested(client, register_routes, computer, person):
@@ -856,7 +856,7 @@ def test_patch_detail_nested(client, register_routes, computer, person):
         response = client.patch('/persons/' + str(person.person_id),
                                 data=json.dumps(payload),
                                 content_type='application/vnd.api+json')
-        assert response.status_code == 200
+        assert response.status_code == 200, response.json['errors']
         response_dict = json.loads(response.get_data())
         assert response_dict['data']['attributes']['tags'][0]['key'] == 'new_key'
         assert response_dict['data']['attributes']['single_tag']['key'] == 'new_single_key'
@@ -865,7 +865,7 @@ def test_patch_detail_nested(client, register_routes, computer, person):
 def test_delete_detail(client, register_routes, person):
     with client:
         response = client.delete('/persons/' + str(person.person_id), content_type='application/vnd.api+json')
-        assert response.status_code == 200
+        assert response.status_code == 200, response.json['errors']
 
 
 def test_get_relationship(session, client, register_routes, computer, person):
@@ -876,14 +876,14 @@ def test_get_relationship(session, client, register_routes, computer, person):
     with client:
         response = client.get('/persons/' + str(person.person_id) + '/relationships/computers?include=computers',
                               content_type='application/vnd.api+json')
-        assert response.status_code == 200
+        assert response.status_code == 200, response.json['errors']
 
 
 def test_get_relationship_empty(client, register_routes, person):
     with client:
         response = client.get('/persons/' + str(person.person_id) + '/relationships/computers?include=computers',
                               content_type='application/vnd.api+json')
-        assert response.status_code == 200
+        assert response.status_code == 200, response.json['errors']
 
 
 def test_get_relationship_single(session, client, register_routes, computer, person):
@@ -894,7 +894,7 @@ def test_get_relationship_single(session, client, register_routes, computer, per
     with client:
         response = client.get('/computers/' + str(computer.id) + '/relationships/owner',
                               content_type='application/vnd.api+json')
-        assert response.status_code == 200
+        assert response.status_code == 200, response.json['errors']
 
 
 def test_get_relationship_single_empty(session, client, register_routes, computer):
@@ -903,7 +903,7 @@ def test_get_relationship_single_empty(session, client, register_routes, compute
                               content_type='application/vnd.api+json')
         response_json = json.loads(response.get_data())
         assert None is response_json['data']
-        assert response.status_code == 200
+        assert response.status_code == 200, response.json['errors']
 
 
 def test_issue_49(session, client, register_routes, person, person_2):
@@ -911,7 +911,7 @@ def test_issue_49(session, client, register_routes, person, person_2):
         for p in [person, person_2]:
             response = client.get('/persons/' + str(p.person_id) + '/relationships/computers?include=computers',
                                   content_type='application/vnd.api+json')
-            assert response.status_code == 200
+            assert response.status_code == 200, response.json['errors']
             assert (json.loads(response.get_data()))['links']['related'] == '/persons/' + str(
                 p.person_id) + '/computers'
 
@@ -930,7 +930,7 @@ def test_post_relationship(client, register_routes, computer, person):
         response = client.post('/persons/' + str(person.person_id) + '/relationships/computers?include=computers',
                                data=json.dumps(payload),
                                content_type='application/vnd.api+json')
-        assert response.status_code == 200
+        assert response.status_code == 200, response.json['errors']
 
 
 def test_post_relationship_not_list(client, register_routes, computer, person):
@@ -945,7 +945,7 @@ def test_post_relationship_not_list(client, register_routes, computer, person):
         response = client.post('/computers/' + str(computer.id) + '/relationships/owner',
                                data=json.dumps(payload),
                                content_type='application/vnd.api+json')
-        assert response.status_code == 200
+        assert response.status_code == 200, response.json['errors']
 
 
 def test_patch_relationship(client, register_routes, computer, person):
@@ -962,7 +962,7 @@ def test_patch_relationship(client, register_routes, computer, person):
         response = client.patch('/persons/' + str(person.person_id) + '/relationships/computers?include=computers',
                                 data=json.dumps(payload),
                                 content_type='application/vnd.api+json')
-        assert response.status_code == 200
+        assert response.status_code == 200, response.json['errors']
 
 
 def test_patch_relationship_single(client, register_routes, computer, person):
@@ -976,7 +976,7 @@ def test_patch_relationship_single(client, register_routes, computer, person):
         response = client.patch('/computers/' + str(computer.id) + '/relationships/owner',
                                 data=json.dumps(payload),
                                 content_type='application/vnd.api+json')
-        assert response.status_code == 200
+        assert response.status_code == 200, response.json['errors']
 
 
 def test_delete_relationship(session, client, register_routes, computer, person):
@@ -997,7 +997,7 @@ def test_delete_relationship(session, client, register_routes, computer, person)
         response = client.delete('/persons/' + str(person.person_id) + '/relationships/computers?include=computers',
                                  data=json.dumps(payload),
                                  content_type='application/vnd.api+json')
-        assert response.status_code == 200
+        assert response.status_code == 200, response.json['errors']
 
 
 def test_delete_relationship_single(session, client, register_routes, computer, person):
@@ -1016,13 +1016,13 @@ def test_delete_relationship_single(session, client, register_routes, computer, 
         response = client.delete('/computers/' + str(computer.id) + '/relationships/owner',
                                  data=json.dumps(payload),
                                  content_type='application/vnd.api+json')
-        assert response.status_code == 200
+        assert response.status_code == 200, response.json['errors']
 
 
 def test_get_list_response(client, register_routes):
     with client:
         response = client.get('/persons_response', content_type='application/vnd.api+json')
-        assert response.status_code == 200
+        assert response.status_code == 200, response.json['errors']
 
 
 # test various Accept headers
@@ -1030,28 +1030,28 @@ def test_single_accept_header(client, register_routes):
     with client:
         response = client.get('/persons', content_type='application/vnd.api+json',
                               headers={'Accept': 'application/vnd.api+json'})
-        assert response.status_code == 200
+        assert response.status_code == 200, response.json['errors']
 
 
 def test_multiple_accept_header(client, register_routes):
     with client:
         response = client.get('/persons', content_type='application/vnd.api+json',
                               headers={'Accept': '*/*, application/vnd.api+json, application/vnd.api+json;q=0.9'})
-        assert response.status_code == 200
+        assert response.status_code == 200, response.json['errors']
 
 
 def test_wrong_accept_header(client, register_routes):
     with client:
         response = client.get('/persons', content_type='application/vnd.api+json',
                               headers={'Accept': 'application/vnd.api+json;q=0.7, application/vnd.api+json;q=0.9'})
-        assert response.status_code == 406
+        assert response.status_code == 406, response.json['errors']
 
 
 # test Content-Type error
 def test_wrong_content_type(client, register_routes):
     with client:
         response = client.post('/persons', headers={'Content-Type': 'application/vnd.api+json;q=0.8'})
-        assert response.status_code == 415
+        assert response.status_code == 415, response.json['errors']
 
 
 @pytest.fixture(scope="module")
@@ -1081,67 +1081,67 @@ def test_wrong_data_layer_kwargs_type():
 def test_get_list_jsonapiexception(client, register_routes):
     with client:
         response = client.get('/persons_jsonapiexception', content_type='application/vnd.api+json')
-        assert response.status_code == 500
+        assert response.status_code == 500, response.json['errors']
 
 
 def test_get_list_exception(client, register_routes):
     with client:
         response = client.get('/persons_exception', content_type='application/vnd.api+json')
-        assert response.status_code == 500
+        assert response.status_code == 500, response.json['errors']
 
 
 def test_get_list_without_schema(client, register_routes):
     with client:
         response = client.post('/persons_without_schema', content_type='application/vnd.api+json')
-        assert response.status_code == 500
+        assert response.status_code == 500, response.json['errors']
 
 
 def test_get_list_bad_request(client, register_routes):
     with client:
         querystring = urlencode({'page[number': 3})
         response = client.get('/persons' + '?' + querystring, content_type='application/vnd.api+json')
-        assert response.status_code == 400
+        assert response.status_code == 400, response.json['errors']
 
 
 def test_get_list_invalid_fields(client, register_routes):
     with client:
         querystring = urlencode({'fields[person]': 'error'})
         response = client.get('/persons' + '?' + querystring, content_type='application/vnd.api+json')
-        assert response.status_code == 400
+        assert response.status_code == 400, response.json['errors']
 
 
 def test_get_list_invalid_include(client, register_routes):
     with client:
         querystring = urlencode({'include': 'error'})
         response = client.get('/persons' + '?' + querystring, content_type='application/vnd.api+json')
-        assert response.status_code == 400
+        assert response.status_code == 400, response.json['errors']
 
 
 def test_get_list_invalid_filters_parsing(client, register_routes):
     with client:
         querystring = urlencode({'filter': 'error'})
         response = client.get('/persons' + '?' + querystring, content_type='application/vnd.api+json')
-        assert response.status_code == 400
+        assert response.status_code == 400, response.json['errors']
 
 
 def test_get_list_invalid_page(client, register_routes):
     with client:
         querystring = urlencode({'page[number]': 'error'})
         response = client.get('/persons' + '?' + querystring, content_type='application/vnd.api+json')
-        assert response.status_code == 400
+        assert response.status_code == 400, response.json['errors']
 
 
 def test_get_list_invalid_sort(client, register_routes):
     with client:
         querystring = urlencode({'sort': 'error'})
         response = client.get('/persons' + '?' + querystring, content_type='application/vnd.api+json')
-        assert response.status_code == 400
+        assert response.status_code == 400, response.json['errors']
 
 
 def test_get_detail_object_not_found(client, register_routes):
     with client:
         response = client.get('/persons/3', content_type='application/vnd.api+json')
-        assert response.status_code == 200
+        assert response.status_code == 200, response.json['errors']
 
 
 def test_post_relationship_related_object_not_found(client, register_routes, person):
@@ -1158,56 +1158,56 @@ def test_post_relationship_related_object_not_found(client, register_routes, per
         response = client.post('/persons/' + str(person.person_id) + '/relationships/computers',
                                data=json.dumps(payload),
                                content_type='application/vnd.api+json')
-        assert response.status_code == 404
+        assert response.status_code == 404, response.json['errors']
 
 
 def test_get_relationship_relationship_field_not_found(client, register_routes, person):
     with client:
         response = client.get('/persons/' + str(person.person_id) + '/relationships/computer',
                               content_type='application/vnd.api+json')
-        assert response.status_code == 500
+        assert response.status_code == 500, response.json['errors']
 
 
 def test_get_list_invalid_filters_val(client, register_routes):
     with client:
         querystring = urlencode({'filter': json.dumps([{'name': 'computers', 'op': 'any'}])})
         response = client.get('/persons' + '?' + querystring, content_type='application/vnd.api+json')
-        assert response.status_code == 400
+        assert response.status_code == 400, response.json['errors']
 
 
 def test_get_list_name(client, register_routes):
     with client:
         querystring = urlencode({'filter': json.dumps([{'name': 'computers__serial', 'op': 'any', 'val': '1'}])})
         response = client.get('/persons' + '?' + querystring, content_type='application/vnd.api+json')
-        assert response.status_code == 200
+        assert response.status_code == 200, response.json['errors']
 
 
 def test_get_list_no_name(client, register_routes):
     with client:
         querystring = urlencode({'filter': json.dumps([{'op': 'any', 'val': '1'}])})
         response = client.get('/persons' + '?' + querystring, content_type='application/vnd.api+json')
-        assert response.status_code == 400
+        assert response.status_code == 400, response.json['errors']
 
 
 def test_get_list_no_op(client, register_routes):
     with client:
         querystring = urlencode({'filter': json.dumps([{'name': 'computers__serial', 'val': '1'}])})
         response = client.get('/persons' + '?' + querystring, content_type='application/vnd.api+json')
-        assert response.status_code == 400
+        assert response.status_code == 400, response.json['errors']
 
 
 def test_get_list_attr_error(client, register_routes):
     with client:
         querystring = urlencode({'filter': json.dumps([{'name': 'error', 'op': 'eq', 'val': '1'}])})
         response = client.get('/persons' + '?' + querystring, content_type='application/vnd.api+json')
-        assert response.status_code == 400
+        assert response.status_code == 400, response.json['errors']
 
 
 def test_get_list_field_error(client, register_routes):
     with client:
         querystring = urlencode({'filter': json.dumps([{'name': 'name', 'op': 'eq', 'field': 'error'}])})
         response = client.get('/persons' + '?' + querystring, content_type='application/vnd.api+json')
-        assert response.status_code == 400
+        assert response.status_code == 400, response.json['errors']
 
 
 def test_sqlalchemy_data_layer_without_session(person_model, person_list):
@@ -1341,7 +1341,7 @@ def test_post_list_incorrect_type(client, register_routes, computer):
 
     with client:
         response = client.post('/persons', data=json.dumps(payload), content_type='application/vnd.api+json')
-        assert response.status_code == 409
+        assert response.status_code == 409, response.json['errors']
 
 
 def test_post_list_validation_error(client, register_routes, computer):
@@ -1364,7 +1364,7 @@ def test_post_list_validation_error(client, register_routes, computer):
 
     with client:
         response = client.post('/persons', data=json.dumps(payload), content_type='application/vnd.api+json')
-        assert response.status_code == 422
+        assert response.status_code == 422, response.json['errors']
 
 
 def test_patch_detail_incorrect_type(client, register_routes, computer, person):
@@ -1392,7 +1392,7 @@ def test_patch_detail_incorrect_type(client, register_routes, computer, person):
         response = client.patch('/persons/' + str(person.person_id),
                                 data=json.dumps(payload),
                                 content_type='application/vnd.api+json')
-        assert response.status_code == 409
+        assert response.status_code == 409, response.json['errors']
 
 
 def test_patch_detail_validation_error(client, register_routes, computer, person):
@@ -1420,7 +1420,7 @@ def test_patch_detail_validation_error(client, register_routes, computer, person
         response = client.patch('/persons/' + str(person.person_id),
                                 data=json.dumps(payload),
                                 content_type='application/vnd.api+json')
-        assert response.status_code == 422
+        assert response.status_code == 422, response.json['errors']
 
 
 def test_patch_detail_missing_id(client, register_routes, computer, person):
@@ -1447,7 +1447,7 @@ def test_patch_detail_missing_id(client, register_routes, computer, person):
         response = client.patch('/persons/' + str(person.person_id),
                                 data=json.dumps(payload),
                                 content_type='application/vnd.api+json')
-        assert response.status_code == 400
+        assert response.status_code == 400, response.json['errors']
 
 
 def test_patch_detail_wrong_id(client, register_routes, computer, person):
@@ -1475,7 +1475,7 @@ def test_patch_detail_wrong_id(client, register_routes, computer, person):
         response = client.patch('/persons/' + str(person.person_id),
                                 data=json.dumps(payload),
                                 content_type='application/vnd.api+json')
-        assert response.status_code == 422
+        assert response.status_code == 422, response.json['errors']
 
 
 def test_post_relationship_no_data(client, register_routes, computer, person):
@@ -1483,7 +1483,7 @@ def test_post_relationship_no_data(client, register_routes, computer, person):
         response = client.post('/persons/' + str(person.person_id) + '/relationships/computers?include=computers',
                                data=json.dumps(dict()),
                                content_type='application/vnd.api+json')
-        assert response.status_code == 400
+        assert response.status_code == 400, response.json['errors']
 
 
 def test_post_relationship_not_list_missing_type(client, register_routes, computer, person):
@@ -1497,7 +1497,7 @@ def test_post_relationship_not_list_missing_type(client, register_routes, comput
         response = client.post('/computers/' + str(computer.id) + '/relationships/owner',
                                data=json.dumps(payload),
                                content_type='application/vnd.api+json')
-        assert response.status_code == 400
+        assert response.status_code == 400, response.json['errors']
 
 
 def test_post_relationship_not_list_missing_id(client, register_routes, computer, person):
@@ -1511,7 +1511,7 @@ def test_post_relationship_not_list_missing_id(client, register_routes, computer
         response = client.post('/computers/' + str(computer.id) + '/relationships/owner',
                                data=json.dumps(payload),
                                content_type='application/vnd.api+json')
-        assert response.status_code == 400
+        assert response.status_code == 400, response.json['errors']
 
 
 def test_post_relationship_not_list_wrong_type(client, register_routes, computer, person):
@@ -1526,7 +1526,7 @@ def test_post_relationship_not_list_wrong_type(client, register_routes, computer
         response = client.post('/computers/' + str(computer.id) + '/relationships/owner',
                                data=json.dumps(payload),
                                content_type='application/vnd.api+json')
-        assert response.status_code == 409
+        assert response.status_code == 409, response.json['errors']
 
 
 def test_post_relationship_missing_type(client, register_routes, computer, person):
@@ -1542,7 +1542,7 @@ def test_post_relationship_missing_type(client, register_routes, computer, perso
         response = client.post('/persons/' + str(person.person_id) + '/relationships/computers?include=computers',
                                data=json.dumps(payload),
                                content_type='application/vnd.api+json')
-        assert response.status_code == 400
+        assert response.status_code == 400, response.json['errors']
 
 
 def test_post_relationship_missing_id(client, register_routes, computer, person):
@@ -1558,7 +1558,7 @@ def test_post_relationship_missing_id(client, register_routes, computer, person)
         response = client.post('/persons/' + str(person.person_id) + '/relationships/computers?include=computers',
                                data=json.dumps(payload),
                                content_type='application/vnd.api+json')
-        assert response.status_code == 400
+        assert response.status_code == 400, response.json['errors']
 
 
 def test_post_relationship_wrong_type(client, register_routes, computer, person):
@@ -1575,7 +1575,7 @@ def test_post_relationship_wrong_type(client, register_routes, computer, person)
         response = client.post('/persons/' + str(person.person_id) + '/relationships/computers?include=computers',
                                data=json.dumps(payload),
                                content_type='application/vnd.api+json')
-        assert response.status_code == 409
+        assert response.status_code == 409, response.json['errors']
 
 
 def test_patch_relationship_no_data(client, register_routes, computer, person):
@@ -1583,7 +1583,7 @@ def test_patch_relationship_no_data(client, register_routes, computer, person):
         response = client.patch('/persons/' + str(person.person_id) + '/relationships/computers?include=computers',
                                 data=json.dumps(dict()),
                                 content_type='application/vnd.api+json')
-        assert response.status_code == 400
+        assert response.status_code == 400, response.json['errors']
 
 
 def test_patch_relationship_not_list_missing_type(client, register_routes, computer, person):
@@ -1597,7 +1597,7 @@ def test_patch_relationship_not_list_missing_type(client, register_routes, compu
         response = client.patch('/computers/' + str(computer.id) + '/relationships/owner',
                                 data=json.dumps(payload),
                                 content_type='application/vnd.api+json')
-        assert response.status_code == 400
+        assert response.status_code == 400, response.json['errors']
 
 
 def test_patch_relationship_not_list_missing_id(client, register_routes, computer, person):
@@ -1611,7 +1611,7 @@ def test_patch_relationship_not_list_missing_id(client, register_routes, compute
         response = client.patch('/computers/' + str(computer.id) + '/relationships/owner',
                                 data=json.dumps(payload),
                                 content_type='application/vnd.api+json')
-        assert response.status_code == 400
+        assert response.status_code == 400, response.json['errors']
 
 
 def test_patch_relationship_not_list_wrong_type(client, register_routes, computer, person):
@@ -1626,7 +1626,7 @@ def test_patch_relationship_not_list_wrong_type(client, register_routes, compute
         response = client.patch('/computers/' + str(computer.id) + '/relationships/owner',
                                 data=json.dumps(payload),
                                 content_type='application/vnd.api+json')
-        assert response.status_code == 409
+        assert response.status_code == 409, response.json['errors']
 
 
 def test_patch_relationship_missing_type(client, register_routes, computer, person):
@@ -1642,7 +1642,7 @@ def test_patch_relationship_missing_type(client, register_routes, computer, pers
         response = client.patch('/persons/' + str(person.person_id) + '/relationships/computers?include=computers',
                                 data=json.dumps(payload),
                                 content_type='application/vnd.api+json')
-        assert response.status_code == 400
+        assert response.status_code == 400, response.json['errors']
 
 
 def test_patch_relationship_missing_id(client, register_routes, computer, person):
@@ -1658,7 +1658,7 @@ def test_patch_relationship_missing_id(client, register_routes, computer, person
         response = client.patch('/persons/' + str(person.person_id) + '/relationships/computers?include=computers',
                                 data=json.dumps(payload),
                                 content_type='application/vnd.api+json')
-        assert response.status_code == 400
+        assert response.status_code == 400, response.json['errors']
 
 
 def test_patch_relationship_wrong_type(client, register_routes, computer, person):
@@ -1675,7 +1675,7 @@ def test_patch_relationship_wrong_type(client, register_routes, computer, person
         response = client.patch('/persons/' + str(person.person_id) + '/relationships/computers?include=computers',
                                 data=json.dumps(payload),
                                 content_type='application/vnd.api+json')
-        assert response.status_code == 409
+        assert response.status_code == 409, response.json['errors']
 
 
 def test_delete_relationship_no_data(client, register_routes, computer, person):
@@ -1683,7 +1683,7 @@ def test_delete_relationship_no_data(client, register_routes, computer, person):
         response = client.delete('/persons/' + str(person.person_id) + '/relationships/computers?include=computers',
                                  data=json.dumps(dict()),
                                  content_type='application/vnd.api+json')
-        assert response.status_code == 400
+        assert response.status_code == 400, response.json['errors']
 
 
 def test_delete_relationship_not_list_missing_type(client, register_routes, computer, person):
@@ -1697,7 +1697,7 @@ def test_delete_relationship_not_list_missing_type(client, register_routes, comp
         response = client.delete('/computers/' + str(computer.id) + '/relationships/owner',
                                  data=json.dumps(payload),
                                  content_type='application/vnd.api+json')
-        assert response.status_code == 400
+        assert response.status_code == 400, response.json['errors']
 
 
 def test_delete_relationship_not_list_missing_id(client, register_routes, computer, person):
@@ -1711,7 +1711,7 @@ def test_delete_relationship_not_list_missing_id(client, register_routes, comput
         response = client.delete('/computers/' + str(computer.id) + '/relationships/owner',
                                  data=json.dumps(payload),
                                  content_type='application/vnd.api+json')
-        assert response.status_code == 400
+        assert response.status_code == 400, response.json['errors']
 
 
 def test_delete_relationship_not_list_wrong_type(client, register_routes, computer, person):
@@ -1726,7 +1726,7 @@ def test_delete_relationship_not_list_wrong_type(client, register_routes, comput
         response = client.delete('/computers/' + str(computer.id) + '/relationships/owner',
                                  data=json.dumps(payload),
                                  content_type='application/vnd.api+json')
-        assert response.status_code == 409
+        assert response.status_code == 409, response.json['errors']
 
 
 def test_delete_relationship_missing_type(client, register_routes, computer, person):
@@ -1742,7 +1742,7 @@ def test_delete_relationship_missing_type(client, register_routes, computer, per
         response = client.delete('/persons/' + str(person.person_id) + '/relationships/computers?include=computers',
                                  data=json.dumps(payload),
                                  content_type='application/vnd.api+json')
-        assert response.status_code == 400
+        assert response.status_code == 400, response.json['errors']
 
 
 def test_delete_relationship_missing_id(client, register_routes, computer, person):
@@ -1758,7 +1758,7 @@ def test_delete_relationship_missing_id(client, register_routes, computer, perso
         response = client.delete('/persons/' + str(person.person_id) + '/relationships/computers?include=computers',
                                  data=json.dumps(payload),
                                  content_type='application/vnd.api+json')
-        assert response.status_code == 400
+        assert response.status_code == 400, response.json['errors']
 
 
 def test_delete_relationship_wrong_type(client, register_routes, computer, person):
@@ -1775,7 +1775,7 @@ def test_delete_relationship_wrong_type(client, register_routes, computer, perso
         response = client.delete('/persons/' + str(person.person_id) + '/relationships/computers?include=computers',
                                  data=json.dumps(payload),
                                  content_type='application/vnd.api+json')
-        assert response.status_code == 409
+        assert response.status_code == 409, response.json['errors']
 
 
 def test_base_data_layer():
@@ -1885,4 +1885,4 @@ def test_relationship_containing_hyphens(api, app, client, person_schema, person
 
     response = client.get('/persons/{}/relationships/computers-owned'.format(person.person_id),
                           content_type='application/vnd.api+json')
-    assert response.status_code == 200
+    assert response.status_code == 200, response.json['errors']

--- a/tests/test_sqlalchemy_data_layer.py
+++ b/tests/test_sqlalchemy_data_layer.py
@@ -28,26 +28,28 @@ import flask_rest_jsonapi.schema
 def base():
     yield declarative_base()
 
+
 @pytest.fixture(scope="module")
 def person_tag_model(base):
     class Person_Tag(base):
-
         __tablename__ = 'person_tag'
 
         id = Column(Integer, ForeignKey('person.person_id'), primary_key=True, index=True)
         key = Column(String, primary_key=True)
         value = Column(String, primary_key=True)
+
     yield Person_Tag
+
 
 @pytest.fixture(scope="module")
 def person_single_tag_model(base):
     class Person_Single_Tag(base):
-
         __tablename__ = 'person_single_tag'
 
         id = Column(Integer, ForeignKey('person.person_id'), primary_key=True, index=True)
         key = Column(String)
         value = Column(String)
+
     yield Person_Single_Tag
 
 
@@ -89,12 +91,13 @@ def string_json_attribute_person_model(base):
         # This model uses a String type for "json_tags" to avoid dependency on a nonstandard SQL type in testing, \
         # while still demonstrating support
         address = Column(MagicJSON)
+
     yield StringJsonAttributePerson
+
 
 @pytest.fixture(scope="module")
 def person_model(base):
     class Person(base):
-
         __tablename__ = 'person'
 
         person_id = Column(Integer, primary_key=True)
@@ -102,21 +105,21 @@ def person_model(base):
         birth_date = Column(DateTime)
         computers = relationship("Computer", backref="person")
         tags = relationship("Person_Tag", cascade="save-update, merge, delete, delete-orphan")
-        single_tag = relationship("Person_Single_Tag", uselist=False, cascade="save-update, merge, delete, delete-orphan")
+        single_tag = relationship("Person_Single_Tag", uselist=False,
+                                  cascade="save-update, merge, delete, delete-orphan")
 
-        computers_owned = relationship("Computer")
     yield Person
 
 
 @pytest.fixture(scope="module")
 def computer_model(base):
     class Computer(base):
-
         __tablename__ = 'computer'
 
         id = Column(Integer, primary_key=True)
         serial = Column(String, nullable=False)
         person_id = Column(Integer, ForeignKey('person.person_id'))
+
     yield Computer
 
 
@@ -175,8 +178,11 @@ def dummy_decorator():
     def deco(f):
         def wrapper_f(*args, **kwargs):
             return f(*args, **kwargs)
+
         return wrapper_f
+
     yield deco
+
 
 @pytest.fixture(scope="module")
 def person_tag_schema():
@@ -184,10 +190,12 @@ def person_tag_schema():
         class Meta:
             type_ = 'person_tag'
 
-        id = fields.Str(dump_only=True, load_only=True)
+        id = fields.Str(load_only=True)
         key = fields.Str()
         value = fields.Str()
+
     yield PersonTagSchema
+
 
 @pytest.fixture(scope="module")
 def person_single_tag_schema():
@@ -195,9 +203,10 @@ def person_single_tag_schema():
         class Meta:
             type_ = 'person_single_tag'
 
-        id = fields.Str(dump_only=True, load_only=True)
+        id = fields.Str(load_only=True)
         key = fields.Str()
         value = fields.Str()
+
     yield PersonSingleTagSchema
 
 
@@ -211,6 +220,7 @@ def address_schema():
 
     yield AddressSchema
 
+
 @pytest.fixture(scope="module")
 def string_json_attribute_person_schema(address_schema):
     class StringJsonAttributePersonSchema(Schema):
@@ -218,7 +228,8 @@ def string_json_attribute_person_schema(address_schema):
             type_ = 'string_json_attribute_person'
             self_view = 'api.string_json_attribute_person_detail'
             self_view_kwargs = {'person_id': '<id>'}
-        id = fields.Integer(as_string=True, dump_only=True, attribute='person_id')
+
+        id = fields.Integer(as_string=True, attribute='person_id')
         name = fields.Str(required=True)
         birth_date = fields.DateTime()
         address = fields.Nested(address_schema, many=False)
@@ -233,19 +244,20 @@ def person_schema(person_tag_schema, person_single_tag_schema):
             type_ = 'person'
             self_view = 'api.person_detail'
             self_view_kwargs = {'person_id': '<id>'}
-        id = fields.Integer(as_string=True, dump_only=True, attribute='person_id')
+
+        id = fields.Integer(as_string=True, attribute='person_id')
         name = fields.Str(required=True)
         birth_date = fields.DateTime()
-        computers = Relationship(related_view='api.computer_list',
-                                 related_view_kwargs={'person_id': '<person_id>'},
-                                 schema='ComputerSchema',
-                                 type_='computer',
-                                 many=True)
+        computers = Relationship(
+            related_view='api.computer_list',
+            related_view_kwargs={'person_id': '<person_id>'},
+            schema='ComputerSchema',
+            type_='computer',
+            many=True,
+        )
 
         tags = fields.Nested(person_tag_schema, many=True)
         single_tag = fields.Nested(person_single_tag_schema)
-
-        computers_owned = computers
 
     yield PersonSchema
 
@@ -257,7 +269,8 @@ def computer_schema():
             type_ = 'computer'
             self_view = 'api.computer_detail'
             self_view_kwargs = {'id': '<id>'}
-        id = fields.Integer(as_string=True, dump_only=True)
+
+        id = fields.Integer(as_string=True)
         serial = fields.Str(required=True)
         owner = Relationship(attribute='person',
                              default=None,
@@ -267,6 +280,7 @@ def computer_schema():
                              schema='PersonSchema',
                              id_field='person_id',
                              type_='person')
+
     yield ComputerSchema
 
 
@@ -274,6 +288,7 @@ def computer_schema():
 def before_create_object():
     def before_create_object_(self, data, view_kwargs):
         pass
+
     yield before_create_object_
 
 
@@ -281,6 +296,7 @@ def before_create_object():
 def before_update_object():
     def before_update_object_(self, obj, data, view_kwargs):
         pass
+
     yield before_update_object_
 
 
@@ -288,6 +304,7 @@ def before_update_object():
 def before_delete_object():
     def before_delete_object_(self, obj, view_kwargs):
         pass
+
     yield before_delete_object_
 
 
@@ -302,6 +319,7 @@ def person_list(session, person_model, dummy_decorator, person_schema, before_cr
         post_decorators = [dummy_decorator]
         get_schema_kwargs = dict()
         post_schema_kwargs = dict()
+
     yield PersonList
 
 
@@ -320,6 +338,7 @@ def person_detail(session, person_model, dummy_decorator, person_schema, before_
         get_schema_kwargs = dict()
         patch_schema_kwargs = dict()
         delete_schema_kwargs = dict()
+
     yield PersonDetail
 
 
@@ -334,6 +353,7 @@ def person_computers(session, person_model, dummy_decorator, person_schema):
         post_decorators = [dummy_decorator]
         patch_decorators = [dummy_decorator]
         delete_decorators = [dummy_decorator]
+
     yield PersonComputersRelationship
 
 
@@ -342,6 +362,7 @@ def person_list_raise_jsonapiexception():
     class PersonList(ResourceList):
         def get(self):
             raise JsonApiException('', '')
+
     yield PersonList
 
 
@@ -350,6 +371,7 @@ def person_list_raise_exception():
     class PersonList(ResourceList):
         def get(self):
             raise Exception()
+
     yield PersonList
 
 
@@ -358,6 +380,7 @@ def person_list_response():
     class PersonList(ResourceList):
         def get(self):
             return make_response('')
+
     yield PersonList
 
 
@@ -369,6 +392,7 @@ def person_list_without_schema(session, person_model):
 
         def get(self):
             return make_response('')
+
     yield PersonList
 
 
@@ -378,6 +402,7 @@ def query():
         if view_kwargs.get('person_id') is not None:
             return self.session.query(computer_model).join(person_model).filter_by(person_id=view_kwargs['person_id'])
         return self.session.query(computer_model)
+
     yield query_
 
 
@@ -388,6 +413,7 @@ def computer_list(session, computer_model, computer_schema, query):
         data_layer = {'model': computer_model,
                       'session': session,
                       'methods': {'query': query}}
+
     yield ComputerList
 
 
@@ -398,6 +424,7 @@ def computer_detail(session, computer_model, dummy_decorator, computer_schema):
         data_layer = {'model': computer_model,
                       'session': session}
         methods = ['GET', 'PATCH']
+
     yield ComputerDetail
 
 
@@ -407,11 +434,13 @@ def computer_owner(session, computer_model, dummy_decorator, computer_schema):
         schema = computer_schema
         data_layer = {'session': session,
                       'model': computer_model}
+
     yield ComputerOwnerRelationship
 
 
 @pytest.fixture(scope="module")
-def string_json_attribute_person_detail(session, string_json_attribute_person_model, string_json_attribute_person_schema):
+def string_json_attribute_person_detail(session, string_json_attribute_person_model,
+                                        string_json_attribute_person_schema):
     class StringJsonAttributePersonDetail(ResourceDetail):
         schema = string_json_attribute_person_schema
         data_layer = {'session': session,
@@ -429,6 +458,7 @@ def string_json_attribute_person_list(session, string_json_attribute_person_mode
 
     yield StringJsonAttributePersonList
 
+
 @pytest.fixture(scope="module")
 def api_blueprint(client):
     bp = Blueprint('api', __name__)
@@ -436,15 +466,18 @@ def api_blueprint(client):
 
 
 @pytest.fixture(scope="module")
-def register_routes(client, app, api_blueprint, person_list, person_detail, person_computers,
+def api(api_blueprint):
+    return Api(blueprint=api_blueprint)
+
+
+@pytest.fixture(scope="module")
+def register_routes(client, api, app, api_blueprint, person_list, person_detail, person_computers,
                     person_list_raise_jsonapiexception, person_list_raise_exception, person_list_response,
                     person_list_without_schema, computer_list, computer_detail, computer_owner,
                     string_json_attribute_person_detail, string_json_attribute_person_list):
-    api = Api(blueprint=api_blueprint)
     api.route(person_list, 'person_list', '/persons')
     api.route(person_detail, 'person_detail', '/persons/<int:person_id>')
     api.route(person_computers, 'person_computers', '/persons/<int:person_id>/relationships/computers')
-    api.route(person_computers, 'person_computers_owned', '/persons/<int:person_id>/relationships/computers-owned')
     api.route(person_computers, 'person_computers_error', '/persons/<int:person_id>/relationships/computer')
     api.route(person_list_raise_jsonapiexception, 'person_list_jsonapiexception', '/persons_jsonapiexception')
     api.route(person_list_raise_exception, 'person_list_exception', '/persons_exception')
@@ -472,6 +505,7 @@ def get_object_mock():
 
         def __init__(self, kwargs):
             pass
+
     return get_object
 
 
@@ -564,7 +598,7 @@ def test_resource(app, person_model, person_schema, session, monkeypatch):
         monkeypatch.setattr(flask_rest_jsonapi.decorators, 'current_app', app)
         monkeypatch.setattr(flask_rest_jsonapi.decorators, 'request', request)
         monkeypatch.setattr(rl.schema, 'load', schema_load_mock)
-        r = super(flask_rest_jsonapi.resource.Resource, ResourceList)\
+        r = super(flask_rest_jsonapi.resource.Resource, ResourceList) \
             .__new__(ResourceList)
         with pytest.raises(Exception):
             r.dispatch_request()
@@ -592,43 +626,46 @@ def test_compute_schema_propagate_context(person_schema, computer_schema):
 # test good cases
 def test_get_list(client, register_routes, person, person_2):
     with client:
-        querystring = urlencode({'page[number]': 1,
-                                 'page[size]': 1,
-                                 'fields[person]': 'name,birth_date',
-                                 'sort': '-name',
-                                 'include': 'computers.owner',
-                                 'filter': json.dumps(
-                                     [
-                                         {
-                                             'and': [
-                                                 {
-                                                     'name': 'computers',
-                                                     'op': 'any',
-                                                     'val': {
-                                                         'name': 'serial',
-                                                         'op': 'eq',
-                                                         'val': '0000'
-                                                     }
-                                                 },
-                                                 {
-                                                     'or': [
-                                                         {
-                                                             'name': 'name',
-                                                             'op': 'like',
-                                                             'val': '%test%'
-                                                         },
-                                                         {
-                                                             'name': 'name',
-                                                             'op': 'like',
-                                                             'val': '%test2%'
-                                                         }
-                                                     ]
-                                                 }
-                                             ]
-                                         }
-                                     ])})
+        querystring = urlencode({
+            'page[number]': 1,
+            'page[size]': 1,
+            'fields[person]': 'name,birth_date',
+            'sort': '-name',
+            'include': 'computers.owner',
+            'filter': json.dumps(
+                [
+                    {
+                        'and': [
+                            {
+                                'name': 'computers',
+                                'op': 'any',
+                                'val': {
+                                    'name': 'serial',
+                                    'op': 'eq',
+                                    'val': '0000'
+                                }
+                            },
+                            {
+                                'or': [
+                                    {
+                                        'name': 'name',
+                                        'op': 'like',
+                                        'val': '%test%'
+                                    },
+                                    {
+                                        'name': 'name',
+                                        'op': 'like',
+                                        'val': '%test2%'
+                                    }
+                                ]
+                            }
+                        ]
+                    }
+                ])
+        })
         response = client.get('/persons' + '?' + querystring, content_type='application/vnd.api+json')
         assert response.status_code == 200
+
 
 def test_get_list_with_simple_filter(client, register_routes, person, person_2):
     with client:
@@ -640,6 +677,7 @@ def test_get_list_with_simple_filter(client, register_routes, person, person_2):
                                  })
         response = client.get('/persons' + '?' + querystring, content_type='application/vnd.api+json')
         assert response.status_code == 200
+
 
 def test_get_list_disable_pagination(client, register_routes):
     with client:
@@ -678,6 +716,7 @@ def test_post_list(client, register_routes, computer):
         response = client.post('/persons', data=json.dumps(payload), content_type='application/vnd.api+json')
         assert response.status_code == 201
 
+
 def test_post_list_nested_no_join(client, register_routes, computer):
     payload = {
         'data': {
@@ -694,10 +733,12 @@ def test_post_list_nested_no_join(client, register_routes, computer):
         }
     }
     with client:
-        response = client.post('/string_json_attribute_persons', data=json.dumps(payload), content_type='application/vnd.api+json')
+        response = client.post('/string_json_attribute_persons', data=json.dumps(payload),
+                               content_type='application/vnd.api+json')
         print(response.get_data())
         assert response.status_code == 201
         assert json.loads(response.get_data())['data']['attributes']['address']['street'] == 'test_street'
+
 
 def test_post_list_nested(client, register_routes, computer):
     payload = {
@@ -757,6 +798,7 @@ def test_get_detail(client, register_routes, person):
         response = client.get('/persons/' + str(person.person_id), content_type='application/vnd.api+json')
         assert response.status_code == 200
 
+
 def test_patch_detail(client, register_routes, computer, person):
     payload = {
         'data': {
@@ -793,9 +835,9 @@ def test_patch_detail_nested(client, register_routes, computer, person):
             'attributes': {
                 'name': 'test2',
                 'tags': [
-                    {'key': 'new_key', 'value': 'new_value' }
+                    {'key': 'new_key', 'value': 'new_value'}
                 ],
-                'single_tag': {'key': 'new_single_key', 'value': 'new_single_value' }
+                'single_tag': {'key': 'new_single_key', 'value': 'new_single_value'}
             },
             'relationships': {
                 'computers': {
@@ -818,7 +860,6 @@ def test_patch_detail_nested(client, register_routes, computer, person):
         response_dict = json.loads(response.get_data())
         assert response_dict['data']['attributes']['tags'][0]['key'] == 'new_key'
         assert response_dict['data']['attributes']['single_tag']['key'] == 'new_single_key'
-
 
 
 def test_delete_detail(client, register_routes, person):
@@ -871,7 +912,8 @@ def test_issue_49(session, client, register_routes, person, person_2):
             response = client.get('/persons/' + str(p.person_id) + '/relationships/computers?include=computers',
                                   content_type='application/vnd.api+json')
             assert response.status_code == 200
-            assert (json.loads(response.get_data()))['links']['related'] == '/persons/' + str(p.person_id) + '/computers'
+            assert (json.loads(response.get_data()))['links']['related'] == '/persons/' + str(
+                p.person_id) + '/computers'
 
 
 def test_post_relationship(client, register_routes, computer, person):
@@ -986,19 +1028,22 @@ def test_get_list_response(client, register_routes):
 # test various Accept headers
 def test_single_accept_header(client, register_routes):
     with client:
-        response = client.get('/persons', content_type='application/vnd.api+json', headers={'Accept': 'application/vnd.api+json'})
+        response = client.get('/persons', content_type='application/vnd.api+json',
+                              headers={'Accept': 'application/vnd.api+json'})
         assert response.status_code == 200
 
 
 def test_multiple_accept_header(client, register_routes):
     with client:
-        response = client.get('/persons', content_type='application/vnd.api+json', headers={'Accept': '*/*, application/vnd.api+json, application/vnd.api+json;q=0.9'})
+        response = client.get('/persons', content_type='application/vnd.api+json',
+                              headers={'Accept': '*/*, application/vnd.api+json, application/vnd.api+json;q=0.9'})
         assert response.status_code == 200
 
 
 def test_wrong_accept_header(client, register_routes):
     with client:
-        response = client.get('/persons', content_type='application/vnd.api+json', headers={'Accept': 'application/vnd.api+json;q=0.7, application/vnd.api+json;q=0.9'})
+        response = client.get('/persons', content_type='application/vnd.api+json',
+                              headers={'Accept': 'application/vnd.api+json;q=0.7, application/vnd.api+json;q=0.9'})
         assert response.status_code == 406
 
 
@@ -1013,6 +1058,7 @@ def test_wrong_content_type(client, register_routes):
 def wrong_data_layer():
     class WrongDataLayer(object):
         pass
+
     yield WrongDataLayer
 
 
@@ -1020,6 +1066,7 @@ def test_wrong_data_layer_inheritence(wrong_data_layer):
     with pytest.raises(Exception):
         class PersonDetail(ResourceDetail):
             data_layer = {'class': wrong_data_layer}
+
         PersonDetail()
 
 
@@ -1027,6 +1074,7 @@ def test_wrong_data_layer_kwargs_type():
     with pytest.raises(Exception):
         class PersonDetail(ResourceDetail):
             data_layer = list()
+
         PersonDetail()
 
 
@@ -1177,6 +1225,7 @@ def test_sqlalchemy_data_layer_create_object_error(session, person_model, person
         dl = SqlalchemyDataLayer(dict(session=session, model=person_model, resource=person_list))
         dl.create_object(dict(), dict())
 
+
 def test_sqlalchemy_data_layer_get_object_error(session, person_model):
     with pytest.raises(Exception):
         dl = SqlalchemyDataLayer(dict(session=session, model=person_model, id_field='error'))
@@ -1186,6 +1235,7 @@ def test_sqlalchemy_data_layer_get_object_error(session, person_model):
 def test_sqlalchemy_data_layer_update_object_error(session, person_model, person_list, monkeypatch):
     def commit_mock():
         raise JsonApiException()
+
     with pytest.raises(JsonApiException):
         dl = SqlalchemyDataLayer(dict(session=session, model=person_model, resource=person_list))
         monkeypatch.setattr(dl.session, 'commit', commit_mock)
@@ -1198,6 +1248,7 @@ def test_sqlalchemy_data_layer_delete_object_error(session, person_model, person
 
     def delete_mock(obj):
         pass
+
     with pytest.raises(JsonApiException):
         dl = SqlalchemyDataLayer(dict(session=session, model=person_model, resource=person_list))
         monkeypatch.setattr(dl.session, 'commit', commit_mock)
@@ -1214,6 +1265,7 @@ def test_sqlalchemy_data_layer_create_relationship_field_not_found(session, pers
 def test_sqlalchemy_data_layer_create_relationship_error(session, person_model, get_object_mock, monkeypatch):
     def commit_mock():
         raise JsonApiException()
+
     with pytest.raises(JsonApiException):
         dl = SqlalchemyDataLayer(dict(session=session, model=person_model))
         monkeypatch.setattr(dl.session, 'commit', commit_mock)
@@ -1236,6 +1288,7 @@ def test_sqlalchemy_data_layer_update_relationship_field_not_found(session, pers
 def test_sqlalchemy_data_layer_update_relationship_error(session, person_model, get_object_mock, monkeypatch):
     def commit_mock():
         raise JsonApiException()
+
     with pytest.raises(JsonApiException):
         dl = SqlalchemyDataLayer(dict(session=session, model=person_model))
         monkeypatch.setattr(dl.session, 'commit', commit_mock)
@@ -1252,6 +1305,7 @@ def test_sqlalchemy_data_layer_delete_relationship_field_not_found(session, pers
 def test_sqlalchemy_data_layer_delete_relationship_error(session, person_model, get_object_mock, monkeypatch):
     def commit_mock():
         raise JsonApiException()
+
     with pytest.raises(JsonApiException):
         dl = SqlalchemyDataLayer(dict(session=session, model=person_model))
         monkeypatch.setattr(dl.session, 'commit', commit_mock)
@@ -1421,7 +1475,7 @@ def test_patch_detail_wrong_id(client, register_routes, computer, person):
         response = client.patch('/persons/' + str(person.person_id),
                                 data=json.dumps(payload),
                                 content_type='application/vnd.api+json')
-        assert response.status_code == 400
+        assert response.status_code == 422
 
 
 def test_post_relationship_no_data(client, register_routes, computer, person):
@@ -1801,6 +1855,34 @@ def test_api_resources(app, person_list):
     api.init_app(app)
 
 
-def test_relationship_containing_hyphens(client, register_routes, person_computers, computer_schema, person):
-    response = client.get('/persons/{}/relationships/computers-owned'.format(person.person_id), content_type='application/vnd.api+json')
+def test_relationship_containing_hyphens(api, app, client, person_schema, person_computers, register_routes,
+                                         computer_schema, person):
+    """
+    This is a bit of a hack. Basically, since we can no longer have two attributes that read from the same key
+    in Marshmallow 3, we have to create a new Schema and Resource here that name their relationship "computers_owned"
+    in order to test hyphenation
+    """
+
+    class PersonOwnedSchema(person_schema):
+        class Meta:
+            exclude = ('computers',)
+
+        computers_owned = Relationship(
+            related_view='api.computer_list',
+            related_view_kwargs={'person_id': '<person_id>'},
+            schema='ComputerSchema',
+            type_='computer',
+            many=True,
+            attribute='computers'
+        )
+
+    class PersonComputersOwnedRelationship(person_computers):
+        schema = PersonOwnedSchema
+
+    api.route(PersonComputersOwnedRelationship, 'person_computers_owned',
+              '/persons/<int:person_id>/relationships/computers-owned')
+    api.init_app(app)
+
+    response = client.get('/persons/{}/relationships/computers-owned'.format(person.person_id),
+                          content_type='application/vnd.api+json')
     assert response.status_code == 200


### PR DESCRIPTION
* Use Marshmallow 3, and fix code and tests that is tied to Marshmallow 2
* Since we're using Marshmallow 3, and since Python 2 is about to hit EOL, remove it from the Travis tests
* Streamline installation by removing `requirements.txt` and adding additional dev packages to the dev extras
* Add helpful assertion messages to the assert statements in the tests
* Add some more recent versions of Python to Travis