### PR TITLE
Automatically filter by the parent resource

### DIFF
--- a/flask_rest_jsonapi/data_layers/alchemy.py
+++ b/flask_rest_jsonapi/data_layers/alchemy.py
@@ -99,16 +99,20 @@ class SqlalchemyDataLayer(BaseDataLayer):
 
         return obj
 
-    def get_collection(self, qs, view_kwargs):
+    def get_collection(self, qs, view_kwargs, filters=None):
         """Retrieve a collection of objects through sqlalchemy
 
         :param QueryStringManager qs: a querystring manager to retrieve information from url
         :param dict view_kwargs: kwargs from the resource view
+        :param dict filters: A dictionary of key/value filters to apply to the eventual query
         :return tuple: the number of object and the list of objects
         """
         self.before_get_collection(qs, view_kwargs)
 
         query = self.query(view_kwargs)
+
+        if filters:
+            query = query.filter_by(**filters)
 
         if qs.filters:
             query = self.filter_query(query, qs.filters, self.model)

--- a/flask_rest_jsonapi/data_layers/base.py
+++ b/flask_rest_jsonapi/data_layers/base.py
@@ -60,11 +60,12 @@ class BaseDataLayer(object):
         """
         raise NotImplementedError
 
-    def get_collection(self, qs, view_kwargs):
+    def get_collection(self, qs, view_kwargs, filters=None):
         """Retrieve a collection of objects
 
         :param QueryStringManager qs: a querystring manager to retrieve information from url
         :param dict view_kwargs: kwargs from the resource view
+        :param dict filters: A dictionary of key/value filters to apply to the eventual query
         :return tuple: the number of object and the list of objects
         """
         raise NotImplementedError


### PR DESCRIPTION
Closes #176.

Broadly this adds a new argument, `filters`, to the `get_collection()` data layer, and then uses this argument to filter the `ResourceList` so that it only returns results attached to a parent resource, e.g. `GET /articles/1/comments` should only return comments for article 1.