### PR TITLE
Get schema kwargs

### DIFF
--- a/tests/test_sqlalchemy_data_layer.py
+++ b/tests/test_sqlalchemy_data_layer.py
@@ -649,6 +649,9 @@ def test_get_list_disable_pagination(client, register_routes):
         assert response.status_code == 200
 
 def test_get_list_class_kwargs(session, person, person_schema, person_model, computer_list):
+    """
+    Test a resource that defines its get_schema_kwargs as a dictionary class variable
+    """
     class PersonDetail(ResourceDetail):
         schema = person_schema
         data_layer = {
@@ -672,6 +675,9 @@ def test_get_list_class_kwargs(session, person, person_schema, person_model, com
     assert 'name' not in ret.json['data']['attributes']
 
 def test_get_list_func_kwargs(session, person, person_schema, person_model, computer_list):
+    """
+    Test a resource that defines its get_schema_kwargs as a function
+    """
     class PersonDetail(ResourceDetail):
         schema = person_schema
         data_layer = {


### PR DESCRIPTION
Allows users to provide fields like `get_schema_kwargs` as functions instead of dictionaries. These functions have access to the view's args and kwargs.

For example:

```python
    class PersonDetail(ResourceDetail):
        schema = person_schema
        data_layer = {
            'model': person_model,
            'session': session,
            'url_field': 'person_id'
        }

        def get_schema_kwargs(self, args, kwargs):
            return dict(
                exclude=['name']
            )
```

You can still use the simpler method of providing a dictionary, too.

I've added two tests for these two use-cases.