### PR TITLE
Allow relationships to be compared to scalars

### DIFF
--- a/flask_rest_jsonapi/data_layers/filtering/alchemy.py
+++ b/flask_rest_jsonapi/data_layers/filtering/alchemy.py
@@ -3,6 +3,7 @@
 """Helper to create sqlalchemy filters according to filter querystring parameter"""
 
 from sqlalchemy import and_, or_, not_
+from sqlalchemy.orm import RelationshipProperty
 
 from flask_rest_jsonapi.exceptions import InvalidFilters
 from flask_rest_jsonapi.schema import get_relationships, get_model_field
@@ -51,6 +52,9 @@ class Node(object):
 
             if isinstance(value, dict):
                 return getattr(self.column, self.operator)(**value)
+            elif isinstance(self.column.prop, RelationshipProperty) and isinstance(value, (int, str)):
+                relationship_key = next(iter(self.column.prop.local_columns))
+                return getattr(relationship_key, self.operator)(value)
             else:
                 return getattr(self.column, self.operator)(value)
 

--- a/flask_rest_jsonapi/resource.py
+++ b/flask_rest_jsonapi/resource.py
@@ -134,7 +134,7 @@ class ResourceList(with_metaclass(ResourceMeta, Resource)):
         add_pagination_links(result,
                              objects_count,
                              qs,
-                             url_for(self.view, _external=True, **view_kwargs))
+                             url_for(request.endpoint, _external=True, **view_kwargs))
 
         result.update({'meta': {'count': objects_count}})
 


### PR DESCRIPTION
This is based on [the recommendations part of the spec](https://jsonapi.org/recommendations/#filtering), which lets you do things like: `GET /comments?filter[post]=1`, even though `filter[post]` isn't actually an integer.

I added a test for this, also