### PR TITLE
schema.py: Fix for get_nested_fields

### DIFF
--- a/flask_rest_jsonapi/schema.py
+++ b/flask_rest_jsonapi/schema.py
@@ -106,7 +106,7 @@ def get_nested_fields(schema, model_field=False):
 
     nested_fields = []
     for (key, value) in schema._declared_fields.items():
-        if isinstance(value, List) and isinstance(value.container, Nested):
+        if isinstance(value, List) and isinstance(value.inner, Nested):
             nested_fields.append(key)
         elif isinstance(value, Nested):
             nested_fields.append(key)


### PR DESCRIPTION
Having a list field on schema is giving an error after upgrading to the latest version. The get_nested_fields function is trying to access an attribute 'container' on a list field, which as per latest marshmallow version does not exist. So replacing it with a new field called 'inner'.