### PR TITLE
log exceptions on non-api fails

### DIFF
--- a/flask_rest_jsonapi/decorators.py
+++ b/flask_rest_jsonapi/decorators.py
@@ -82,6 +82,7 @@ def jsonapi_exception_formatter(func):
         except Exception as e:
             if current_app.config['DEBUG'] is True or current_app.config.get('PROPAGATE_EXCEPTIONS') is True:
                 raise
+            current_app.log_exception(e)
 
             if 'sentry' in current_app.extensions:
                 current_app.extensions['sentry'].captureException()


### PR DESCRIPTION
If not using debug mode, non-JsonApiExceptions are only returned to the requestor and not logged. This makes it difficult to detect when requests are failing and what is causing the exceptions.