### PR TITLE
Resetting `api.app.view_functions` to the initial state

### DIFF
--- a/tests/test_sqlalchemy_data_layer.py
+++ b/tests/test_sqlalchemy_data_layer.py
@@ -1895,6 +1895,7 @@ def test_api_resources(app, person_list):
     api = Api()
     api.route(person_list, 'person_list2', '/persons', '/person_list')
     api.init_app(app)
+    api.app.view_functions.clear()
 
 
 def test_relationship_containing_hyphens(api, app, client, person_schema, person_computers, register_routes,

--- a/tests/test_sqlalchemy_data_layer.py
+++ b/tests/test_sqlalchemy_data_layer.py
@@ -1888,6 +1888,7 @@ def test_api(app, person_list):
     api = Api(app)
     api.route(person_list, 'person_list', '/persons', '/person_list')
     api.init_app()
+    api.app.view_functions.clear()
 
 
 def test_api_resources(app, person_list):


### PR DESCRIPTION
This PR aims to improve test reliability of test `test_api` by resetting `api.app.view_functions` to the initial state by calling method `clear`

The test can fail in this way by running `pip3 install pytest-repeat; python3 -m pytest --count=2 $test_path`:

```
    def test_api(app, person_list):
        api = Api(app)
>       api.route(person_list, 'person_list', '/persons', '/person_list')

...

        if view_func is not None:
            old_func = self.view_functions.get(endpoint)
            if old_func is not None and old_func != view_func:
>               raise AssertionError(
                    "View function mapping is overwriting an existing"
                    f" endpoint function: {endpoint}"
                )
E               AssertionError: View function mapping is overwriting an existing endpoint function: person_list

```

It may be better to clean state pollutions so that some other tests won't fail in the future due to the shared state pollution.
