### PR TITLE
update docs

### DIFF
--- a/docs/filtering.rst
+++ b/docs/filtering.rst
@@ -58,11 +58,11 @@ If you want to filter through relationships you can do that:
 
     When you filter on relationships use "any" operator for "to many" relationships and "has" operator for "to one" relationships.
 
-There is a shortcut to achieve the same filter:
+For filters where the nested operator is *eq* (as opposed to *ilike* in the above), a shortcut is available:
 
 .. sourcecode:: http
 
-    GET /persons?filter=[{"name":"computers__serial","op":"ilike","val":"%Amstrad%"}] HTTP/1.1
+    GET /persons?filter=[{"name":"computers__serial","op":"any","val":"Amstrad"}] HTTP/1.1
     Accept: application/vnd.api+json
 
 You can also use boolean combination of operations:
@@ -72,8 +72,8 @@ You can also use boolean combination of operations:
     GET /persons?filter=[
       {
         "name":"computers__serial",
-        "op":"ilike",
-        "val":"%Amstrad%"
+        "op":"any",
+        "val":"Amstrad"
       },
       {
         "or": [


### PR DESCRIPTION
Hi, and thank you for this project

I tried running this sample shortcut relationship filter against the example api, but I ran into a problem that looks like
`GET /persons?filter=[{"name":"computers__serial","op":"ilike","val":"%Amstrad%"}] HTTP/1.1`
```
127.0.0.1 - - [24/Sep/2021 00:18:58] "GET /persons?filter=%5B%7B%22name%22%3A+%22computers__serial%22%2C+%22op%22%3A+%22ilike%22%2C+%22val%22%3A+%22%25Amstrad%25%22%7D%5D HTTP/1.1" 500 -
Traceback (most recent call last):
  File "/Users/erich/.pyenv/versions/3.9.4/envs/frj/lib/python3.9/site-packages/flask/app.py", line 2088, in __call__
    return self.wsgi_app(environ, start_response)
 . . . 
  File "/Users/erich/.pyenv/versions/3.9.4/envs/frj/lib/python3.9/site-packages/flask_rest_jsonapi/data_layers/filtering/alchemy.py", line 20, in create_filters
    filters.append(Node(model, filter_, resource, resource.schema).resolve())
  File "/Users/erich/.pyenv/versions/3.9.4/envs/frj/lib/python3.9/site-packages/flask_rest_jsonapi/data_layers/filtering/alchemy.py", line 53, in resolve
    return getattr(self.column, self.operator)(**value)
TypeError: ilike() got an unexpected keyword argument 'serial'
```
It looks like this is because the filter ultimately is becoming `Computer.ilike(serial="%Amstrad%")`.  So this is to update the example to a filter that becomes `Computer.any(serial="Amstrad")` 